### PR TITLE
Fix for 1.9

### DIFF
--- a/lib/sql-logging/logged_query.rb
+++ b/lib/sql-logging/logged_query.rb
@@ -20,14 +20,22 @@ class LoggedQuery
   
   def [](key)
     case key.to_sym
-    when :sql: @sql
-    when :name: @name
-    when :backtrace: @backtrace
-    when :queries: @queries
-    when :rows: @rows
-    when :bytes: @bytes
-    when :median_time: median_time
-    when :total_time: total_time
+    when :sql
+      @sql
+    when :name
+      @name
+    when :backtrace
+      @backtrace
+    when :queries
+      @queries
+    when :rows
+      @rows
+    when :bytes
+      @bytes
+    when :median_time
+      median_time
+    when :total_time
+      total_time
     else nil
     end
   end


### PR DESCRIPTION
I fixed some stuff that was giving me syntax errors in Ruby 1.9.2. I _assume_ those are incompatibilities betweem 1.8.7 and the 1.9 branch, and they were easy to fix by changing the syntax a little.

It should now work in both 1.8.7 and 1.9.x
