### PR TITLE
ActiveRecord renamed `name` to `adapter_name`

### DIFF
--- a/lib/sql-logging/adapters/postgresql.rb
+++ b/lib/sql-logging/adapters/postgresql.rb
@@ -4,13 +4,13 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   def execute_with_sql_logging(sql, *args)
     result = nil
     elapsed = Benchmark.measure do
-      result = execute_without_sql_logging(sql, adapter_name)
+      result = execute_without_sql_logging(sql, *args)
     end
     msec = elapsed.real * 1000
     if result.respond_to?(:rows)
-      SqlLogging::Statistics.record_query(sql, adapter_name, msec, result.rows)
+      SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
     else
-      SqlLogging::Statistics.record_query(sql, adapter_name, msec, result)
+      SqlLogging::Statistics.record_query(sql, args.first, msec, result)
     end
     result
   end


### PR DESCRIPTION
Rails has renamed the `name` property on ActiveRecord adapters to `adapter_name`. [(See here.)](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html)

This pull request fixes the following error on Rails 3.2 boot when sql-logging is installed:

```
/Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/sql-logging-3.0.6/lib/sql-logging/adapters/postgresql.rb:7:in `block in execute_with_sql_logging': undefined local variable or method `name' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x007fb09477d340> (NameError)
from /Users/eleos/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/benchmark.rb:295:in `measure'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/sql-logging-3.0.6/lib/sql-logging/adapters/postgresql.rb:6:in `execute_with_sql_logging'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:905:in `client_min_messages='
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:390:in `ensure in set_standard_conforming_strings'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:390:in `set_standard_conforming_strings'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:1214:in `configure_connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:1201:in `connect'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:329:in `initialize'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:28:in `new'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:28:in `postgresql_connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:277:in `new_connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:287:in `checkout_new_connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:235:in `block (2 levels) in checkout'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:230:in `loop'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:230:in `block in checkout'
from /Users/eleos/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:229:in `checkout'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:95:in `connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:374:in `retrieve_connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_specification.rb:168:in `retrieve_connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/connection_adapters/abstract/connection_specification.rb:142:in `connection'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/model_schema.rb:308:in `clear_cache!'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.2.2/lib/active_record/railtie.rb:91:in `block (2 levels) in <class:Railtie>'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:418:in `_run__894647593047244254__prepare__2989842558191019128__callbacks'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:405:in `__run_callback'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:385:in `_run_prepare_callbacks'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/callbacks.rb:81:in `run_callbacks'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/actionpack-3.2.2/lib/action_dispatch/middleware/reloader.rb:74:in `prepare!'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/actionpack-3.2.2/lib/action_dispatch/middleware/reloader.rb:48:in `prepare!'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/application/finisher.rb:47:in `block in <module:Finisher>'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/initializable.rb:30:in `instance_exec'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/initializable.rb:30:in `run'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/initializable.rb:55:in `block in run_initializers'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/initializable.rb:54:in `each'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/initializable.rb:54:in `run_initializers'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/application.rb:136:in `initialize!'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/railtie/configurable.rb:30:in `method_missing'
from /Users/eleos/axle/config/environment.rb:5:in `<top (required)>'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `require'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `block in require'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:236:in `load_dependency'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `require'
from /Users/eleos/axle/config.ru:4:in `block in <main>'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/builder.rb:51:in `instance_eval'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/builder.rb:51:in `initialize'
from /Users/eleos/axle/config.ru:1:in `new'
from /Users/eleos/axle/config.ru:1:in `<main>'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/builder.rb:40:in `eval'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/builder.rb:40:in `parse_file'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/server.rb:200:in `app'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/commands/server.rb:46:in `app'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/server.rb:301:in `wrapped_app'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/rack-1.4.1/lib/rack/server.rb:252:in `start'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/commands/server.rb:70:in `start'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/commands.rb:55:in `block in <top (required)>'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/commands.rb:50:in `tap'
from /Users/eleos/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.2.2/lib/rails/commands.rb:50:in `<top (required)>'
from script/rails:6:in `require'
from script/rails:6:in `<main>'
```
