### PR TITLE
Add ActiveRecord::ConnectionAdapters::Mysql2Adapter adapter

### DIFF
--- a/lib/sql-logging/adapters/pedant_mysql2.rb
+++ b/lib/sql-logging/adapters/pedant_mysql2.rb
@@ -1,0 +1,15 @@
+require 'active_record/connection_adapters/pedant_mysql2_adapter'
+
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  def select_with_sql_logging(sql, *args)
+    rows = nil
+    elapsed = Benchmark.measure do
+      rows = select_without_sql_logging(sql, *args)
+    end
+    msec = elapsed.real * 1000
+    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
+    rows
+  end
+
+  alias_method_chain :select, :sql_logging
+end


### PR DESCRIPTION
Add the adapter for `ActiveRecord::ConnectionAdapters::Mysql2Adapter`

https://rubygems.org/gems/activerecord-pedantmysql2-adapter
