### PR TITLE
Fixed Sqlite3 / Added Firebird

### DIFF
--- a/lib/sql-logging/adapters/cache_extension.rb
+++ b/lib/sql-logging/adapters/cache_extension.rb
@@ -5,13 +5,9 @@ module ActiveRecord::ConnectionAdapters::QueryCache
 
   def cache_sql_with_sql_logging(sql, binds, &blk)
     if @query_cache.has_key?(sql)
-      rows = nil
-      elapsed = Benchmark.measure do
-        rows = cache_sql_without_sql_logging(sql, binds, &blk)
+      SqlLogging::Statistics.benchmark(sql, 'CACHE') do
+        cache_sql_without_sql_logging(sql, binds, &blk)
       end
-      msec = elapsed.real * 1000
-      SqlLogging::Statistics.record_query(sql, "CACHE", msec, rows)
-      rows
     else
       cache_sql_without_sql_logging(sql, binds, &blk)
     end

--- a/lib/sql-logging/adapters/fb.rb
+++ b/lib/sql-logging/adapters/fb.rb
@@ -1,0 +1,6 @@
+require 'sql-logging/adapters/generic'
+require 'active_record/connection_adapters/fb_adapter'
+
+class ActiveRecord::ConnectionAdapters::FbAdapter
+  include SqlLogging::Adapters::Generic
+end

--- a/lib/sql-logging/adapters/generic.rb
+++ b/lib/sql-logging/adapters/generic.rb
@@ -1,0 +1,27 @@
+module SqlLogging
+  module Adapters
+    module Generic
+      def self.included(base)
+        base.class_eval do
+          alias_method_chain :execute, :sql_logging
+
+          if method_defined? :exec_query
+            alias_method_chain :exec_query, :sql_logging
+          end
+        end
+      end
+
+      def execute_with_sql_logging(sql, name = nil)
+        SqlLogging::Statistics.benchmark(sql, name) do
+          execute_without_sql_logging(sql, name)
+        end
+      end
+
+      def exec_query_with_sql_logging(sql, name = nil, binds = [])
+        SqlLogging::Statistics.benchmark(sql, name) do
+          exec_query_without_sql_logging(sql, name, binds)
+        end
+      end
+    end
+  end
+end

--- a/lib/sql-logging/adapters/generic_mysql.rb
+++ b/lib/sql-logging/adapters/generic_mysql.rb
@@ -1,0 +1,17 @@
+module SqlLogging
+  module Adapters
+    module GenericMysql
+      def self.included(base)
+        base.class_eval do
+          alias_method_chain :select, :sql_logging
+        end
+      end
+
+      def select_with_sql_logging(sql, *args)
+        SqlLogging::Statistics.benchmark(sql, args.first) do
+          select_without_sql_logging(sql, *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/sql-logging/adapters/mysql.rb
+++ b/lib/sql-logging/adapters/mysql.rb
@@ -1,15 +1,6 @@
+require 'sql-logging/adapters/generic_mysql'
 require 'active_record/connection_adapters/mysql_adapter'
 
 class ActiveRecord::ConnectionAdapters::MysqlAdapter
-  def select_with_sql_logging(sql, *args)
-    rows = nil
-    elapsed = Benchmark.measure do
-      rows = select_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
-    rows
-  end
-  
-  alias_method_chain :select, :sql_logging
+  include SqlLogging::Adapters::GenericMysql
 end

--- a/lib/sql-logging/adapters/mysql2.rb
+++ b/lib/sql-logging/adapters/mysql2.rb
@@ -1,15 +1,6 @@
+require 'sql-logging/adapters/generic_mysql'
 require 'active_record/connection_adapters/mysql2_adapter'
 
 class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  def select_with_sql_logging(sql, *args)
-    rows = nil
-    elapsed = Benchmark.measure do
-      rows = select_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
-    rows
-  end
-  
-  alias_method_chain :select, :sql_logging
+  include SqlLogging::Adapters::GenericMysql
 end

--- a/lib/sql-logging/adapters/pedant_mysql2.rb
+++ b/lib/sql-logging/adapters/pedant_mysql2.rb
@@ -1,15 +1,6 @@
+require 'sql-logging/adapters/generic_mysql'
 require 'active_record/connection_adapters/pedant_mysql2_adapter'
 
 class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  def select_with_sql_logging(sql, *args)
-    rows = nil
-    elapsed = Benchmark.measure do
-      rows = select_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
-    rows
-  end
-
-  alias_method_chain :select, :sql_logging
+  include SqlLogging::Adapters::GenericMysql
 end

--- a/lib/sql-logging/adapters/postgresql.rb
+++ b/lib/sql-logging/adapters/postgresql.rb
@@ -1,45 +1,14 @@
+require 'sql-logging/adapters/generic'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-  def execute_with_sql_logging(sql, *args)
-    result = nil
-    elapsed = Benchmark.measure do
-      result = execute_without_sql_logging(sql, *args)
+  include SqlLogging::Adapters::Generic
+
+  def exec_delete_with_sql_logging(sql, name = nil, binds = [])
+    SqlLogging::Statistics.benchmark(sql, name) do
+      exec_delete_without_sql_logging(sql, name, binds)
     end
-    msec = elapsed.real * 1000
-    if result.respond_to?(:rows)
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
-    else
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result)
-    end
-    result
   end
-  
-  def exec_query_with_sql_logging(sql, *args)
-    result = nil
-    elapsed = Benchmark.measure do
-      result = exec_query_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    if result.respond_to?(:rows)
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
-    else
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result)
-    end
-    result
-  end
-  
-  def exec_delete_with_sql_logging(sql, *args)
-    result = nil
-    elapsed = Benchmark.measure do
-      result = exec_delete_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, result)
-    result
-  end
-  
-  alias_method_chain :execute, :sql_logging
-  alias_method_chain :exec_query, :sql_logging
+
   alias_method_chain :exec_delete, :sql_logging
 end

--- a/lib/sql-logging/adapters/sqlite.rb
+++ b/lib/sql-logging/adapters/sqlite.rb
@@ -1,13 +1,6 @@
-class ActiveRecord::ConnectionAdapters::SQLiteAdapter
-  def execute_with_sql_logging(sql, name = nil)
-    res = nil
-    elapsed = Benchmark.measure do
-      res = execute_without_sql_logging(sql, name)
-    end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, name, msec, res)
-    res
-  end
+require 'sql-logging/connection_adapters/generic'
+require 'active_record/connection_adapters/sqlite_adapter'
 
-  alias_method_chain :execute, :sql_logging
+class ActiveRecord::ConnectionAdapters::SQLiteAdapter
+  include SqlLogging::Adapters::Generic
 end

--- a/lib/sql-logging/adapters/sqlite3.rb
+++ b/lib/sql-logging/adapters/sqlite3.rb
@@ -1,1 +1,6 @@
-require 'sql-logging/adapters/sqlite'
+require 'sql-logging/adapters/generic'
+require 'active_record/connection_adapters/sqlite3_adapter'
+
+class ActiveRecord::ConnectionAdapters::SQLite3Adapter
+  include SqlLogging::Adapters::Generic
+end

--- a/lib/sql-logging/railtie.rb
+++ b/lib/sql-logging/railtie.rb
@@ -15,7 +15,7 @@ module SqlLogging
         end
       end
     end
-    
+
     initializer 'sql_logging.reset_statistics' do
       ActiveSupport.on_load(:active_record) do
         ActionDispatch::Callbacks.before do


### PR DESCRIPTION
+ SQLiteAdapter was removed in AR 4.0. Therefore, it needs it's own adapter.
+ Added support for Firebird database.
+ Dried up some repetition. Adding new adapters should now be very simple.

Heads up: I didn't actually test mysql or pg.