### PR TITLE
Update travis dependencies to include rails 5 and ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: ruby
 
 rvm:
-  - 2.0.0
-  - 2.1.7
   - 2.2.3
-  - 2.3.0-preview1
+  - 2.3.2
+  - 2.4.0
 
 gemfile:
-  - Gemfile.rails31
-  - Gemfile.rails32
   - Gemfile.rails40
   - Gemfile.rails41
   - Gemfile.rails42
+  - Gemfile.rails50
+
+matrix:
+  exclude:
+  - rvm: 2.4.0
+    gemfile: Gemfile.rails40
+  - rvm: 2.4.0
+    gemfile: Gemfile.rails41
+  - rvm: 2.4.0
+    gemfile: Gemfile.rails42
 
 sudo: false

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'rails', '~> 3.2.0'

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rails', '~> 3.1.0'
+gem 'rails', '~> 5.0.0'


### PR DESCRIPTION
Tune up some of the travis settings by removing old targets and adding some of the recent releases.

## Remove
- Ruby 2.0.0
- Ruby 2.1.7
- Ruby 2.3.0-preview1
- Gemfile.rails31
- Gemfile.rails32

## Add
- Ruby 2.3.2
- Ruby 2.4.0 (Rails 5 only, earlier Rails fail to build native extension)
