### PR TITLE
Migrate from using 'alias_method_chain' to use 'Module#prepend' to support Rails 5.1.1

### DIFF
--- a/lib/sql-logging/adapters/cache_extension.rb
+++ b/lib/sql-logging/adapters/cache_extension.rb
@@ -1,21 +1,25 @@
 require 'active_record/connection_adapters/abstract/query_cache'
 
 module ActiveRecord::ConnectionAdapters::QueryCache
-  private
-
-  def cache_sql_with_sql_logging(sql, binds, &blk)
-    if @query_cache.has_key?(sql)
-      rows = nil
-      elapsed = Benchmark.measure do
-        rows = cache_sql_without_sql_logging(sql, binds, &blk)
+  module CacheSQLWithSqlLogging
+    def cache_sql(sql, binds, &blk)
+      if @query_cache.has_key?(sql)
+        rows = nil
+        elapsed = Benchmark.measure do
+          rows = super(sql, binds, &blk)
+        end
+        msec = elapsed.real * 1000
+        SqlLogging::Statistics.record_query(sql, "CACHE", msec, rows)
+        rows
+      else
+        super(sql, binds, &blk)
       end
-      msec = elapsed.real * 1000
-      SqlLogging::Statistics.record_query(sql, "CACHE", msec, rows)
-      rows
-    else
-      cache_sql_without_sql_logging(sql, binds, &blk)
     end
   end
 
-  alias_method_chain :cache_sql, :sql_logging
+  private
+
+  def self.included(klass)
+    klass.prepend CacheSQLWithSqlLogging
+  end
 end

--- a/lib/sql-logging/adapters/mysql.rb
+++ b/lib/sql-logging/adapters/mysql.rb
@@ -1,15 +1,19 @@
 require 'active_record/connection_adapters/mysql_adapter'
 
-class ActiveRecord::ConnectionAdapters::MysqlAdapter
-  def select_with_sql_logging(sql, *args)
-    rows = nil
-    elapsed = Benchmark.measure do
-      rows = select_without_sql_logging(sql, *args)
+module ActiveRecord::ConnectionAdapters
+  module SelectWithSqlLogging
+    def select(sql, *args)
+      rows = nil
+      elapsed = Benchmark.measure do
+        rows = super(sql, *args)
+      end
+      msec = elapsed.real * 1000
+      SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
+      rows
     end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
-    rows
   end
-  
-  alias_method_chain :select, :sql_logging
+
+  class MysqlAdapter
+    prepend SelectWithSqlLogging
+  end
 end

--- a/lib/sql-logging/adapters/mysql2.rb
+++ b/lib/sql-logging/adapters/mysql2.rb
@@ -1,15 +1,19 @@
 require 'active_record/connection_adapters/mysql2_adapter'
 
-class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  def select_with_sql_logging(sql, *args)
-    rows = nil
-    elapsed = Benchmark.measure do
-      rows = select_without_sql_logging(sql, *args)
+module ActiveRecord::ConnectionAdapters
+  module SelectWithSqlLogging
+    def select(sql, *args)
+      rows = nil
+      elapsed = Benchmark.measure do
+        rows = super(sql, *args)
+      end
+      msec = elapsed.real * 1000
+      SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
+      rows
     end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
-    rows
   end
-  
-  alias_method_chain :select, :sql_logging
+
+  class Mysql2Adapter
+    prepend SelectWithSqlLogging
+  end
 end

--- a/lib/sql-logging/adapters/pedant_mysql2.rb
+++ b/lib/sql-logging/adapters/pedant_mysql2.rb
@@ -1,15 +1,19 @@
 require 'active_record/connection_adapters/pedant_mysql2_adapter'
 
-class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  def select_with_sql_logging(sql, *args)
-    rows = nil
-    elapsed = Benchmark.measure do
-      rows = select_without_sql_logging(sql, *args)
+module ActiveRecord::ConnectionAdapters
+  module SelectWithSqlLogging
+    def select(sql, *args)
+      rows = nil
+      elapsed = Benchmark.measure do
+        rows = super(sql, *args)
+      end
+      msec = elapsed.real * 1000
+      SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
+      rows
     end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, rows)
-    rows
   end
 
-  alias_method_chain :select, :sql_logging
+  class Mysql2Adapter
+    prepend SelectWithSqlLogging
+  end
 end

--- a/lib/sql-logging/adapters/postgresql.rb
+++ b/lib/sql-logging/adapters/postgresql.rb
@@ -1,45 +1,53 @@
 require 'active_record/connection_adapters/postgresql_adapter'
 
-class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-  def execute_with_sql_logging(sql, *args)
-    result = nil
-    elapsed = Benchmark.measure do
-      result = execute_without_sql_logging(sql, *args)
+module ActiveRecord::ConnectionAdapters
+  module ExecuteWithSqlLogging
+    def execute(sql, *args)
+      result = nil
+      elapsed = Benchmark.measure do
+        result = super(sql, *args)
+      end
+      msec = elapsed.real * 1000
+      if result.respond_to?(:rows)
+        SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
+      else
+        SqlLogging::Statistics.record_query(sql, args.first, msec, result)
+      end
+      result
     end
-    msec = elapsed.real * 1000
-    if result.respond_to?(:rows)
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
-    else
+  end
+
+  module ExecQueryWithSqlLogging
+    def exec_query(sql, *args)
+      result = nil
+      elapsed = Benchmark.measure do
+        result = super(sql, *args)
+      end
+      msec = elapsed.real * 1000
+      if result.respond_to?(:rows)
+        SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
+      else
+        SqlLogging::Statistics.record_query(sql, args.first, msec, result)
+      end
+      result
+    end
+  end
+
+  module ExecDeleteWithSqlLogging
+    def exec_delete(sql, *args)
+      result = nil
+      elapsed = Benchmark.measure do
+        result = super(sql, *args)
+      end
+      msec = elapsed.real * 1000
       SqlLogging::Statistics.record_query(sql, args.first, msec, result)
+      result
     end
-    result
   end
-  
-  def exec_query_with_sql_logging(sql, *args)
-    result = nil
-    elapsed = Benchmark.measure do
-      result = exec_query_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    if result.respond_to?(:rows)
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result.rows)
-    else
-      SqlLogging::Statistics.record_query(sql, args.first, msec, result)
-    end
-    result
+
+  class PostgreSQLAdapter
+    prepend ExecuteWithSqlLogging
+    prepend ExecQueryWithSqlLogging
+    prepend ExecDeleteWithSqlLogging
   end
-  
-  def exec_delete_with_sql_logging(sql, *args)
-    result = nil
-    elapsed = Benchmark.measure do
-      result = exec_delete_without_sql_logging(sql, *args)
-    end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, args.first, msec, result)
-    result
-  end
-  
-  alias_method_chain :execute, :sql_logging
-  alias_method_chain :exec_query, :sql_logging
-  alias_method_chain :exec_delete, :sql_logging
 end

--- a/lib/sql-logging/adapters/sqlite.rb
+++ b/lib/sql-logging/adapters/sqlite.rb
@@ -1,13 +1,17 @@
-class ActiveRecord::ConnectionAdapters::SQLiteAdapter
-  def execute_with_sql_logging(sql, name = nil)
-    res = nil
-    elapsed = Benchmark.measure do
-      res = execute_without_sql_logging(sql, name)
+module ActiveRecord::ConnectionAdapters
+  module ExecuteWithSqlLogging
+    def execute(sql, name = nil)
+      res = nil
+      elapsed = Benchmark.measure do
+        res = super(sql, name)
+      end
+      msec = elapsed.real * 1000
+      SqlLogging::Statistics.record_query(sql, name, msec, res)
+      res
     end
-    msec = elapsed.real * 1000
-    SqlLogging::Statistics.record_query(sql, name, msec, res)
-    res
   end
 
-  alias_method_chain :execute, :sql_logging
+  class SQLiteAdapter
+    prepend ExecuteWithSqlLogging
+  end
 end


### PR DESCRIPTION
In Rails 5.1.1, 'alias_method_chain' has been removed, this will use 'Module#prepend' instead to support the latest Rails 5.1.1 version.