### PR TITLE
Remove deprecated has_rdoc from the gemspec

### DIFF
--- a/sql-logging.gemspec
+++ b/sql-logging.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.description = 'Adds SQL analysis and debugging info to Rails applications.'
   s.files = Dir.glob('lib/**/*').to_a
   s.require_path = 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc']
 
   s.add_dependency('rails', '>= 4.0')


### PR DESCRIPTION
Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.